### PR TITLE
WUK Curslack1 NanoStations

### DIFF
--- a/static.conf
+++ b/static.conf
@@ -98,6 +98,26 @@ host osterrade-ap4 {
 	fixed-address 10.112.0.33;
 }
 
+host curslack1-no {
+	hardware ethernet 68:72:51:3e:87:66;
+	fixed-address 10.112.0.34;
+}
+
+host curslack1-so {
+	hardware ethernet 68:72:51:3e:85:1d;
+	fixed-address 10.112.0.35;
+}
+
+host curslack1-sw {
+	hardware ethernet 68:72:51:3e:85:2e;
+	fixed-address 10.112.0.36;
+}
+
+host curslack1-nw {
+	hardware ethernet 68:72:51:3e:85:9e;
+	fixed-address 10.112.0.37;
+}
+
 host srv01.hamburg.freifunk.net {
         hardware ethernet de:ad:be:ef:08:15;
         fixed-address 10.112.1.1;


### PR DESCRIPTION
Für die Flüchtlings WohnUnterKunft Curslack1 in Bergedorf. Möchte die 4 AccessPoints mit original Firmware betreiben. Statische IP nötig zwecks Erreichbarkeit für Administration.