### PR TITLE
Update static.conf

### DIFF
--- a/static.conf
+++ b/static.conf
@@ -133,6 +133,11 @@ host weidenbaum-AP3 {
 	fixed-address 10.112.0.40;
 }
 
+host WR1043-AP1 {
+	hardware ethernet 30:b5:c2:6f:0f:e2;
+	fixed-address 10.112.0.41;
+}
+
 host frutro {
     hardware ethernet 00:19:99:dd:49:c8;
     fixed-address 10.112.0.42;
@@ -176,6 +181,16 @@ host WA701-AP1 {
 host WA701-AP2 {
 	hardware ethernet 60:e3:27:d1:61:44;
 	fixed-address 10.112.0.50;
+}
+
+host WR1043-AP2 {
+	hardware ethernet c4:6e:1f:40:f5:be;
+	fixed-address 10.112.0.51;
+}
+
+host WR1043-AP3 {
+	hardware ethernet 14:cc:20:b9:a3:80;
+	fixed-address 10.112.0.52;
 }
 
 host srv01.hamburg.freifunk.net {

--- a/static.conf
+++ b/static.conf
@@ -118,9 +118,64 @@ host curslack1-nw {
 	fixed-address 10.112.0.37;
 }
 
+host weidenbaum-AP1 {
+	hardware ethernet 60:e3:27:9f:59:26;
+	fixed-address 10.112.0.38;
+}
+
+host weidenbaum-AP2 {
+	hardware ethernet 60:e3:27:9f:4f:8a;
+	fixed-address 10.112.0.39;
+}
+
+host weidenbaum-AP3 {
+	hardware ethernet 60:e3:27:9f:50:9a;
+	fixed-address 10.112.0.40;
+}
+
 host frutro {
     hardware ethernet 00:19:99:dd:49:c8;
     fixed-address 10.112.0.42;
+}
+
+host WR840-AP1 {
+	hardware ethernet a4:2b:b0:eb:01:4a;
+	fixed-address 10.112.0.43;
+}
+
+host WR840-AP2 {
+	hardware ethernet a4:2b:b0:eb:01:3c;
+	fixed-address 10.112.0.44;
+}
+
+host WR840-AP3 {
+	hardware ethernet a4:2b:b0:c1:2c:b4;
+	fixed-address 10.112.0.45;
+}
+
+host WR840-AP4 {
+	hardware ethernet a4:2b:b0:eb:0f:36;
+	fixed-address 10.112.0.46;
+}
+
+host WR840-AP5 {
+	hardware ethernet a4:2b:b0:eb:00:b4;
+	fixed-address 10.112.0.47;
+}
+
+host WR840-AP5 {
+	hardware ethernet a4:2b:b0:eb:00:b6;
+	fixed-address 10.112.0.48;
+}
+
+host WA701-AP1 {
+	hardware ethernet 60:e3:27:d1:60:e1;
+	fixed-address 10.112.0.49;
+}
+
+host WA701-AP2 {
+	hardware ethernet 60:e3:27:d1:61:44;
+	fixed-address 10.112.0.50;
 }
 
 host srv01.hamburg.freifunk.net {


### PR DESCRIPTION
Mehrere Access Points bei größeren Installationen in Flüchtlingsheimen hinzugefügt.
Nun IP .42 für host futro ausgelassen.